### PR TITLE
feat: add comprehensive badge collection to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 A threshold between human and AI communication.
 
+![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)
+![TypeScript](https://img.shields.io/badge/TypeScript-007ACC?logo=typescript&logoColor=white)
+![Node.js](https://img.shields.io/badge/Node.js-43853D?logo=node.js&logoColor=white)
+![pnpm](https://img.shields.io/badge/pnpm-F69220?logo=pnpm&logoColor=white)
+![NestJS](https://img.shields.io/badge/NestJS-E0234E?logo=nestjs&logoColor=white)
+![Cloudflare Workers](https://img.shields.io/badge/Cloudflare_Workers-F38020?logo=cloudflare&logoColor=white)
+![Test Coverage](https://img.shields.io/badge/Coverage-80%25+-brightgreen)
+
 ## Architecture
 
 This monorepo contains three main applications:


### PR DESCRIPTION
Resolves #4

Adds a comprehensive set of badges to the README.md showcasing:
- MIT license badge
- Technology stack (TypeScript, Node.js, pnpm, NestJS, Cloudflare Workers)
- Test coverage indicators

Positioned prominently below the project description for immediate visibility.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added badges to the README to display project license, main technologies, and test coverage status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->