### PR TITLE
ci and cd  GHA workflow implementation [PP]

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,103 @@
+name: CD
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Deployment environment"
+        required: true
+        default: staging
+        type: choice
+        options:
+          - staging
+          - production
+      target:
+        description: "What to deploy"
+        required: true
+        default: both
+        type: choice
+        options:
+          - both
+          - api
+          - web
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.environment }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-api:
+    if: >
+      (github.event_name == 'workflow_dispatch' && inputs.target != 'web') ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main')
+    name: Deploy Convex API
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: ${{ inputs.environment || 'staging' }}
+    env:
+      # Provided per-environment via GitHub Environments (Secrets/Variables)
+      CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+      CONVEX_DEPLOYMENT: ${{ vars.CONVEX_DEPLOYMENT }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8.15.9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Convex types
+        working-directory: apps/liminal-api
+        run: pnpm exec convex codegen
+
+      - name: Deploy Convex
+        working-directory: apps/liminal-api
+        run: |
+          if [ "${{ inputs.environment }}" = "production" ]; then
+            pnpm exec convex deploy --prod
+          else
+            pnpm exec convex deploy
+          fi
+
+  deploy-web:
+    if: >
+      (github.event_name == 'workflow_dispatch' && inputs.target != 'api') ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main')
+    name: Deploy Web (Vercel)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: ${{ inputs.environment || 'staging' }}
+    # No explicit dependency; both can run independently
+    env:
+      # Public build-time env for Next.js
+      NEXT_PUBLIC_CONVEX_URL: ${{ vars.NEXT_PUBLIC_CONVEX_URL }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy to Vercel
+        uses: amondnet/vercel-action@v20
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: apps/web
+          vercel-args: ${{ inputs.environment == 'production' && '--prod' || '' }}
+        env:
+          NEXT_PUBLIC_CONVEX_URL: ${{ vars.NEXT_PUBLIC_CONVEX_URL }}
+
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,16 @@ jobs:
           pnpm -F web typecheck
           pnpm -F @liminal/api typecheck
 
-      - name: Build
-        run: |
-          pnpm -F @liminal/chat build
-          pnpm -F web build
-          pnpm -F @liminal/api build
+      - name: Build @liminal/chat
+        run: pnpm -F @liminal/chat build
+
+      - name: Build web (Next.js)
+        run: pnpm -F web build
+        env:
+          NEXT_PUBLIC_CONVEX_URL: https://example.convex.cloud
+
+      - name: Build @liminal/api
+        run: pnpm -F @liminal/api build
 
       - name: Unit tests (@liminal/chat)
         run: pnpm -F @liminal/chat test -- --run --reporter=dot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8.15.9
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 8.15.9
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Generate Convex types (@liminal/api)
+        working-directory: apps/liminal-api
+        run: pnpm exec convex codegen
+
       - name: Lint
         run: |
           pnpm -F @liminal/chat lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.9
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: |
+          pnpm -F @liminal/chat lint
+          pnpm -F web lint
+          pnpm -F @liminal/api lint
+
+      - name: Typecheck
+        run: |
+          pnpm -F @liminal/chat typecheck
+          pnpm -F web typecheck
+          pnpm -F @liminal/api typecheck
+
+      - name: Build
+        run: |
+          pnpm -F @liminal/chat build
+          pnpm -F web build
+          pnpm -F @liminal/api build
+
+      - name: Unit tests (@liminal/chat)
+        run: pnpm -F @liminal/chat test -- --run --reporter=dot
+
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    environment: staging
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Build web (Next.js)
         run: pnpm -F web build
         env:
-          NEXT_PUBLIC_CONVEX_URL: https://example.convex.cloud
+          NEXT_PUBLIC_CONVEX_URL: ${{ vars.NEXT_PUBLIC_CONVEX_URL }}
 
       - name: Build @liminal/api
         run: pnpm -F @liminal/api build


### PR DESCRIPTION
Hi Lee,

I implemented the ci.yml workflow with dummy NEXT_PUBLIC_CONVEX_URL for now. 

**Here are the sample run of GHA.**

https://github.com/parimalpate123/liminal-chat/actions

**Need your help on this setup in https://github.com/leegmoore/liminal-chat**

### Required GitHub Environment config (staging and production)

Add these to each environment in GitHub:
- Environment: staging
- Environment: production

Secrets (sensitive)
- CONVEX_DEPLOY_KEY: Convex deploy key for that environment
- VERCEL_TOKEN: Vercel access token
- VERCEL_ORG_ID: Vercel org ID
- VERCEL_PROJECT_ID: Vercel project ID for `apps/web`

Variables (non-sensitive)
- CONVEX_DEPLOYMENT: Convex deployment slug (e.g., modest-squirrel-498)
- NEXT_PUBLIC_CONVEX_URL: Public Convex URL for that environment (from Convex dashboard)

Notes
- CI uses the staging environment. Ensure `staging` has `NEXT_PUBLIC_CONVEX_URL` set or Next.js build will fail.
- CD reads all values from the selected environment when you run `cd.yml`.

Where to get values
- CONVEX_DEPLOY_KEY, CONVEX_DEPLOYMENT, NEXT_PUBLIC_CONVEX_URL:
  - Convex dashboard → your project → deployment settings (URL and slug shown there; deploy key under Settings/Keys)
- VERCEL_TOKEN:
  - Vercel account settings → Tokens
- VERCEL_ORG_ID, VERCEL_PROJECT_ID:
  - Vercel → Project → Settings → General (IDs)
  - Or via CLI: `vercel link` will print them

How to add them (per environment)
- GitHub → Settings → Environments → New environment → “staging”
- Open “staging” → Add secret → name and value (repeat for each secret)
- Add variable → name and value (repeat for each variable)
- Repeat for “production” with production values

Optional (only if you enable post‑deploy tests later)
- Secrets for local JWT minting and provider APIs:
  - SYSTEM_USER_EMAIL, SYSTEM_USER_PASSWORD, WORKOS_CLIENT_ID, WORKOS_API_KEY
  - OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY, OPENROUTER_API_KEY, PERPLEXITY_API_KEY, VERCEL_API_TOKEN
- Typically set these in Convex dashboard for runtime; only add to GitHub if you plan to manage them from CI.